### PR TITLE
Update code from 0.25.3: add max retry

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -211,7 +211,7 @@ impl ConnectionManager {
             .factor(factor)
             .number_of_retries(number_of_retries);
 
-        Self::new_with_backoff_and_timeouts_with_max_delay_retry(
+        Self::new_with_backoff_and_timeouts_with_max_delay(
             client,
             retry_strategy_info,
             response_timeout,

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -211,12 +211,13 @@ impl ConnectionManager {
             .factor(factor)
             .number_of_retries(number_of_retries);
 
-        Self::new_with_backoff_and_timeouts_with_max_delay(
+       Self::new_with_backoff_and_timeouts_with_max_delay(
             client,
             retry_strategy_info,
             response_timeout,
             connection_timeout,
         )
+        .await
     }
 
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -17,6 +17,62 @@ use std::sync::Arc;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 
+/// Apply a maximum delay. No retry delay will be longer than this `max_delay`.
+#[derive(Clone, Debug, Default)]
+pub struct RetryStrategyInfo {
+    /// The resulting duration is calculated by taking the base to the `n`-th power,
+    /// where `n` denotes the number of past attempts.
+    pub exponent_base: u64,
+    /// A multiplicative factor that will be applied to the retry delay.
+    ///
+    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    pub factor: u64,
+    /// number_of_retries times, with an exponentially increasing delay
+    pub number_of_retries: usize,
+    /// Apply a maximum delay. No retry delay will be longer than this 'duration' milliseconds.
+    pub max_delay: Option<u64>,
+}
+
+impl RetryStrategyInfo {
+    const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
+    const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
+    const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
+
+    /// Creates a new instance of the options with nothing set
+    pub fn new() -> Self {
+        Self {
+            exponent_base: Self::DEFAULT_CONNECTION_RETRY_EXPONENT_BASE,
+            factor: Self::DEFAULT_CONNECTION_RETRY_FACTOR,
+            number_of_retries: Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIESE,
+            max_delay: None,
+        }
+    }
+
+    /// Sets the factor
+    pub fn factor(mut self, factor: u64) -> RetryStrategyInfo {
+        self.factor = factor;
+        self
+    }
+
+    /// Sets the max_delay
+    pub fn max_delay(mut self, duration: u64) -> RetryStrategyInfo {
+        self.max_delay = Some(duration);
+        self
+    }
+
+    /// Sets the exponent_base
+    pub fn exponent_base(mut self, duration: u64) -> RetryStrategyInfo {
+        self.exponent_base = duration;
+        self
+    }
+
+    /// Sets the number_of_retries
+    pub fn number_of_retries(mut self, duration: usize) -> RetryStrategyInfo {
+        self.number_of_retries = duration;
+        self
+    }
+}
+
 /// A `ConnectionManager` is a proxy that wraps a [multiplexed
 /// connection][multiplexed-connection] and automatically reconnects to the
 /// server when necessary.
@@ -90,20 +146,18 @@ macro_rules! reconnect_if_io_error {
 }
 
 impl ConnectionManager {
-    const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
-    const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
-    const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
-
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
     ///
     /// This requires the `connection-manager` feature, which will also pull in
     /// the Tokio executor.
     pub async fn new(client: Client) -> RedisResult<Self> {
+        let retry_strategy_info = RetryStrategyInfo::new();
+
         Self::new_with_backoff(
             client,
-            Self::DEFAULT_CONNECTION_RETRY_EXPONENT_BASE,
-            Self::DEFAULT_CONNECTION_RETRY_FACTOR,
-            Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIESE,
+            retry_strategy_info.exponent_base,
+            retry_strategy_info.factor,
+            retry_strategy_info.number_of_retries,
         )
         .await
     }
@@ -152,18 +206,54 @@ impl ConnectionManager {
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<Self> {
-        // Create a MultiplexedConnection and wait for it to be established
+        let retry_strategy_info = RetryStrategyInfo::new()
+            .exponent_base(exponent_base)
+            .factor(factor)
+            .number_of_retries(number_of_retries);
 
-        let runtime = Runtime::locate();
-        let retry_strategy = ExponentialBackoff::from_millis(exponent_base).factor(factor);
-        let connection = Self::new_connection(
-            client.clone(),
-            retry_strategy.clone(),
-            number_of_retries,
+        Self::new_with_backoff_and_timeouts_with_max_delay_retry(
+            client,
+            retry_strategy_info,
             response_timeout,
             connection_timeout,
         )
-        .await?;
+    }
+
+    /// Connect to the server and store the connection inside the returned `ConnectionManager`.
+    ///
+    /// This requires the `connection-manager` feature, which will also pull in
+    /// the Tokio executor.
+    ///
+    /// In case of reconnection issues, the manager will retry reconnection
+    /// number_of_retries times, with an exponentially increasing delay, calculated as
+    /// rand(0 .. factor * (exponent_base ^ current-try)).
+    ///
+    /// The new connection will timeout operations after `response_timeout` has passed.
+    /// Each connection attempt to the server will timeout after `connection_timeout`.
+    pub async fn new_with_backoff_and_timeouts_with_max_delay(
+        client: Client,
+        retry_strategy_info: RetryStrategyInfo,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<Self> {
+        // Create a MultiplexedConnection and wait for it to be established
+
+        let runtime = Runtime::locate();
+        // let retry_strategy = ExponentialBackoff::from_millis(exponent_base).factor(factor);
+        let mut retry_strategy = ExponentialBackoff::from_millis(retry_strategy_info.exponent_base)
+            .factor(retry_strategy_info.factor);
+        if let Some(max_delay) = retry_strategy_info.max_delay {
+            retry_strategy = retry_strategy.max_delay(std::time::Duration::from_millis(max_delay));
+        }
+
+        let connection = Self::new_connection(
+            client.clone(),
+            retry_strategy.clone(),
+            retry_strategy_info.number_of_retries,
+            response_timeout,
+            connection_timeout,
+        )
+            .await?;
 
         // Wrap the connection in an `ArcSwap` instance for fast atomic access
         Ok(Self {
@@ -172,7 +262,7 @@ impl ConnectionManager {
                 future::ok(connection).boxed().shared(),
             )),
             runtime,
-            number_of_retries,
+            number_of_retries: retry_strategy_info.number_of_retries,
             retry_strategy,
             response_timeout,
             connection_timeout,

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -57,37 +57,43 @@ impl ConnectionManagerConfig {
     }
 
     /// Sets the factor
-    pub fn factor(mut self, factor: u64) -> ConnectionManagerConfig {
+    pub fn set_factor(mut self, factor: u64) -> ConnectionManagerConfig {
         self.factor = factor;
         self
     }
 
     /// Sets the max_delay
-    pub fn max_delay(mut self, time: u64) -> ConnectionManagerConfig {
+    pub fn set_max_delay(mut self, time: u64) -> ConnectionManagerConfig {
         self.max_delay = Some(time);
         self
     }
 
     /// Sets the exponent_base
-    pub fn exponent_base(mut self, base: u64) -> ConnectionManagerConfig {
+    pub fn set_exponent_base(mut self, base: u64) -> ConnectionManagerConfig {
         self.exponent_base = base;
         self
     }
 
     /// Sets the number_of_retries
-    pub fn number_of_retries(mut self, amount: usize) -> ConnectionManagerConfig {
+    pub fn set_number_of_retries(mut self, amount: usize) -> ConnectionManagerConfig {
         self.number_of_retries = amount;
         self
     }
 
     /// Sets the response_timeout
-    pub fn response_timeout(mut self, duration: std::time::Duration) -> ConnectionManagerConfig {
+    pub fn set_response_timeout(
+        mut self,
+        duration: std::time::Duration,
+    ) -> ConnectionManagerConfig {
         self.response_timeout = duration;
         self
     }
 
     /// Sets the response_timeout
-    pub fn connection_timeout(mut self, duration: std::time::Duration) -> ConnectionManagerConfig {
+    pub fn set_connection_timeout(
+        mut self,
+        duration: std::time::Duration,
+    ) -> ConnectionManagerConfig {
         self.connection_timeout = duration;
         self
     }
@@ -221,11 +227,11 @@ impl ConnectionManager {
         connection_timeout: std::time::Duration,
     ) -> RedisResult<Self> {
         let config = ConnectionManagerConfig::new()
-            .exponent_base(exponent_base)
-            .factor(factor)
-            .number_of_retries(number_of_retries)
-            .response_timeout(response_timeout)
-            .connection_timeout(connection_timeout);
+            .set_exponent_base(exponent_base)
+            .set_factor(factor)
+            .set_number_of_retries(number_of_retries)
+            .set_response_timeout(response_timeout)
+            .set_connection_timeout(connection_timeout);
 
         Self::new_with_config(client, config).await
     }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -19,24 +19,30 @@ use tokio_retry::Retry;
 
 /// Apply a maximum delay. No retry delay will be longer than this `max_delay`.
 #[derive(Clone, Debug, Default)]
-pub struct RetryStrategyInfo {
+pub struct ConnectionConfigInfo {
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub exponent_base: u64,
+    exponent_base: u64,
     /// A multiplicative factor that will be applied to the retry delay.
     ///
     /// For example, using a factor of `1000` will make each delay in units of seconds.
-    pub factor: u64,
+    factor: u64,
     /// number_of_retries times, with an exponentially increasing delay
-    pub number_of_retries: usize,
+    number_of_retries: usize,
     /// Apply a maximum delay. No retry delay will be longer than this 'duration' milliseconds.
-    pub max_delay: Option<u64>,
+    max_delay: Option<u64>,
+    /// The new connection will timeout operations after `response_timeout` has passed.
+    response_timeout: std::time::Duration,
+    /// Each connection attempt to the server will timeout after `connection_timeout`.
+    connection_timeout: std::time::Duration,
 }
 
-impl RetryStrategyInfo {
+impl ConnectionConfigInfo {
     const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
     const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
     const DEFAULT_NUMBER_OF_CONNECTION_RETRIESE: usize = 6;
+    const DEFAULT_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::MAX;
+    const DEFAULT_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::MAX;
 
     /// Creates a new instance of the options with nothing set
     pub fn new() -> Self {
@@ -45,30 +51,44 @@ impl RetryStrategyInfo {
             factor: Self::DEFAULT_CONNECTION_RETRY_FACTOR,
             number_of_retries: Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIESE,
             max_delay: None,
+            response_timeout: Self::DEFAULT_RESPONSE_TIMEOUT,
+            connection_timeout: Self::DEFAULT_CONNECTION_TIMEOUT,
         }
     }
 
     /// Sets the factor
-    pub fn factor(mut self, factor: u64) -> RetryStrategyInfo {
+    pub fn factor(mut self, factor: u64) -> ConnectionConfigInfo {
         self.factor = factor;
         self
     }
 
     /// Sets the max_delay
-    pub fn max_delay(mut self, duration: u64) -> RetryStrategyInfo {
+    pub fn max_delay(mut self, duration: u64) -> ConnectionConfigInfo {
         self.max_delay = Some(duration);
         self
     }
 
     /// Sets the exponent_base
-    pub fn exponent_base(mut self, duration: u64) -> RetryStrategyInfo {
+    pub fn exponent_base(mut self, duration: u64) -> ConnectionConfigInfo {
         self.exponent_base = duration;
         self
     }
 
     /// Sets the number_of_retries
-    pub fn number_of_retries(mut self, duration: usize) -> RetryStrategyInfo {
-        self.number_of_retries = duration;
+    pub fn number_of_retries(mut self, amount: usize) -> ConnectionConfigInfo {
+        self.number_of_retries = amount;
+        self
+    }
+
+    /// Sets the response_timeout
+    pub fn response_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+        self.response_timeout = duration;
+        self
+    }
+
+    /// Sets the response_timeout
+    pub fn connection_timeout(mut self, duration: std::time::Duration) -> ConnectionConfigInfo {
+        self.connection_timeout = duration;
         self
     }
 }
@@ -151,13 +171,13 @@ impl ConnectionManager {
     /// This requires the `connection-manager` feature, which will also pull in
     /// the Tokio executor.
     pub async fn new(client: Client) -> RedisResult<Self> {
-        let retry_strategy_info = RetryStrategyInfo::new();
+        let config = ConnectionConfigInfo::new();
 
         Self::new_with_backoff(
             client,
-            retry_strategy_info.exponent_base,
-            retry_strategy_info.factor,
-            retry_strategy_info.number_of_retries,
+            config.exponent_base,
+            config.factor,
+            config.number_of_retries,
         )
         .await
     }
@@ -206,18 +226,14 @@ impl ConnectionManager {
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<Self> {
-        let retry_strategy_info = RetryStrategyInfo::new()
+        let config = ConnectionConfigInfo::new()
             .exponent_base(exponent_base)
             .factor(factor)
-            .number_of_retries(number_of_retries);
+            .number_of_retries(number_of_retries)
+            .response_timeout(response_timeout)
+            .connection_timeout(connection_timeout);
 
-       Self::new_with_backoff_and_timeouts_with_max_delay(
-            client,
-            retry_strategy_info,
-            response_timeout,
-            connection_timeout,
-        )
-        .await
+        Self::new_with_backoff_and_timeouts_new_with_config(client, config).await
     }
 
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
@@ -225,36 +241,35 @@ impl ConnectionManager {
     /// This requires the `connection-manager` feature, which will also pull in
     /// the Tokio executor.
     ///
+    /// Apply a maximum delay. No retry delay will be longer than this  ConnectionConfigInfo.max_delay .
+    ///
     /// In case of reconnection issues, the manager will retry reconnection
     /// number_of_retries times, with an exponentially increasing delay, calculated as
     /// rand(0 .. factor * (exponent_base ^ current-try)).
     ///
     /// The new connection will timeout operations after `response_timeout` has passed.
     /// Each connection attempt to the server will timeout after `connection_timeout`.
-    pub async fn new_with_backoff_and_timeouts_with_max_delay(
+    pub async fn new_with_backoff_and_timeouts_new_with_config(
         client: Client,
-        retry_strategy_info: RetryStrategyInfo,
-        response_timeout: std::time::Duration,
-        connection_timeout: std::time::Duration,
+        config: ConnectionConfigInfo,
     ) -> RedisResult<Self> {
         // Create a MultiplexedConnection and wait for it to be established
 
         let runtime = Runtime::locate();
-        // let retry_strategy = ExponentialBackoff::from_millis(exponent_base).factor(factor);
-        let mut retry_strategy = ExponentialBackoff::from_millis(retry_strategy_info.exponent_base)
-            .factor(retry_strategy_info.factor);
-        if let Some(max_delay) = retry_strategy_info.max_delay {
+        let mut retry_strategy =
+            ExponentialBackoff::from_millis(config.exponent_base).factor(config.factor);
+        if let Some(max_delay) = config.max_delay {
             retry_strategy = retry_strategy.max_delay(std::time::Duration::from_millis(max_delay));
         }
 
         let connection = Self::new_connection(
             client.clone(),
             retry_strategy.clone(),
-            retry_strategy_info.number_of_retries,
-            response_timeout,
-            connection_timeout,
+            config.number_of_retries,
+            config.response_timeout,
+            config.connection_timeout,
         )
-            .await?;
+        .await?;
 
         // Wrap the connection in an `ArcSwap` instance for fast atomic access
         Ok(Self {
@@ -263,10 +278,10 @@ impl ConnectionManager {
                 future::ok(connection).boxed().shared(),
             )),
             runtime,
-            number_of_retries: retry_strategy_info.number_of_retries,
+            number_of_retries: config.number_of_retries,
             retry_strategy,
-            response_timeout,
-            connection_timeout,
+            response_timeout: config.response_timeout,
+            connection_timeout: config.connection_timeout,
         })
     }
 

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -483,11 +483,11 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
-    pub async fn get_tokio_connection_manager_with_backoff_and_timeouts_new_with_config(
+    pub async fn get_connection_manager_with_config(
         &self,
-        config: crate::aio::ConnectionConfigInfo,
+        config: crate::aio::ConnectionManagerConfig,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
+        crate::aio::ConnectionManager::new_with_config(
             self.clone(),
             config,
         )

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -486,8 +486,6 @@ impl Client {
     pub async fn get_tokio_connection_manager_with_backoff_and_timeouts_new_with_config(
         &self,
         config: crate::aio::ConnectionConfigInfo,
-        response_timeout: std::time::Duration,
-        connection_timeout: std::time::Duration,
     ) -> RedisResult<crate::aio::ConnectionManager> {
         crate::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
             self.clone(),

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -483,17 +483,15 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
-    pub async fn get_tokio_connection_manager_with_backoff_and_timeouts_with_max_delay(
+    pub async fn get_tokio_connection_manager_with_backoff_and_timeouts_new_with_config(
         &self,
-        retry_strategy_info: crate::aio::RetryStrategyInfo,
+        config: crate::aio::ConnectionConfigInfo,
         response_timeout: std::time::Duration,
         connection_timeout: std::time::Duration,
     ) -> RedisResult<crate::aio::ConnectionManager> {
-        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay(
+        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
             self.clone(),
-            retry_strategy_info,
-            response_timeout,
-            connection_timeout,
+            config,
         )
         .await
     }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -483,6 +483,40 @@ impl Client {
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_tokio_connection_manager_with_backoff_and_timeouts_with_max_delay(
+        &self,
+        retry_strategy_info: crate::aio::RetryStrategyInfo,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        crate::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay(
+            self.clone(),
+            retry_strategy_info,
+            response_timeout,
+            connection_timeout,
+        )
+        .await
+    }
+
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
     pub async fn get_connection_manager_with_backoff(
         &self,
         exponent_base: u64,

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -89,7 +89,6 @@ fn test_block_on_all_panics_from_spawns() {
     });
     assert!(result.is_err());
 }
-
 #[cfg(feature = "async-std-comp")]
 pub fn block_on_all_using_async_std<F>(f: F) -> F::Output
 where

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -835,7 +835,7 @@ fn test_connection_manager_reconnect_after_delay() {
 #[cfg(feature = "connection-manager")]
 fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
     /// Factor set 10 seconds, but max retry delay set 500 millisecond
-    let retry_strategy_info = redis::aio::RetryStrategyInfo::new()
+    let config = redis::aio::ConnectionConfigInfo::new()
         .factor(10000)
         .max_delay(500);
 
@@ -848,14 +848,12 @@ fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
     let ctx = TestContext::with_tls(tls_files.clone(), false);
     block_on_all(async move {
         let mut manager =
-            redis::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay(
+            redis::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
                 ctx.client.clone(),
-                retry_strategy_info.clone(),
-                std::time::Duration::MAX,
-                std::time::Duration::MAX,
+                config,
             )
-                .await
-                .unwrap();
+            .await
+            .unwrap();
         let server = ctx.server;
         let addr = server.client_addr().clone();
         drop(server);
@@ -871,7 +869,7 @@ fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
         assert_eq!(result, redis::Value::Okay);
         Ok(())
     })
-        .unwrap();
+    .unwrap();
 }
 
 #[cfg(feature = "tls-rustls")]

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -836,8 +836,8 @@ fn test_connection_manager_reconnect_after_delay() {
 fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
     /// Factor set 10 seconds, but max retry delay set 500 millisecond
     let config = redis::aio::ConnectionManagerConfig::new()
-        .factor(10000)
-        .max_delay(500);
+        .set_factor(10000)
+        .set_max_delay(500);
 
     let tempdir = tempfile::Builder::new()
         .prefix("redis")

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -831,6 +831,49 @@ fn test_connection_manager_reconnect_after_delay() {
     .unwrap();
 }
 
+#[test]
+#[cfg(feature = "connection-manager")]
+fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
+    /// Factor set 10 seconds, but max retry delay set 500 millisecond
+    let retry_strategy_info = redis::aio::RetryStrategyInfo::new()
+        .factor(10000)
+        .max_delay(500);
+
+    let tempdir = tempfile::Builder::new()
+        .prefix("redis")
+        .tempdir()
+        .expect("failed to create tempdir");
+    let tls_files = build_keys_and_certs_for_tls(&tempdir);
+
+    let ctx = TestContext::with_tls(tls_files.clone(), false);
+    block_on_all(async move {
+        let mut manager =
+            redis::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay(
+                ctx.client.clone(),
+                retry_strategy_info.clone(),
+                std::time::Duration::MAX,
+                std::time::Duration::MAX,
+            )
+                .await
+                .unwrap();
+        let server = ctx.server;
+        let addr = server.client_addr().clone();
+        drop(server);
+
+        let _result: RedisResult<redis::Value> = manager.set("foo", "bar").await; // one call is ignored because it's required to trigger the connection manager's reconnect.
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let _new_server = RedisServer::new_with_addr_and_modules(addr.clone(), &[], false);
+        wait_for_server_to_become_ready(ctx.client.clone()).await;
+
+        let result: redis::Value = manager.set("foo", "bar").await.unwrap();
+        assert_eq!(result, redis::Value::Okay);
+        Ok(())
+    })
+        .unwrap();
+}
+
 #[cfg(feature = "tls-rustls")]
 mod mtls_test {
     use super::*;

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -835,7 +835,7 @@ fn test_connection_manager_reconnect_after_delay() {
 #[cfg(feature = "connection-manager")]
 fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
     /// Factor set 10 seconds, but max retry delay set 500 millisecond
-    let config = redis::aio::ConnectionConfigInfo::new()
+    let config = redis::aio::ConnectionManagerConfig::new()
         .factor(10000)
         .max_delay(500);
 
@@ -848,7 +848,7 @@ fn test_connection_manager_reconnect_after_delay_with_retry_delay() {
     let ctx = TestContext::with_tls(tls_files.clone(), false);
     block_on_all(async move {
         let mut manager =
-            redis::aio::ConnectionManager::new_with_backoff_and_timeouts_new_with_config(
+            redis::aio::ConnectionManager::new_with_config(
                 ctx.client.clone(),
                 config,
             )


### PR DESCRIPTION
Add a redis::aio::ConnectionManager::new_with_backoff_and_timeouts_with_max_delay Apply a maximum delay. No retry delay will be longer than this max_delay.